### PR TITLE
Update market aggregator to load tokens/mints

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,11 @@
   "dependencies": {
     "@project-serum/anchor": "^0.16.2",
     "@project-serum/serum": "^0.13.59",
+    "@saberhq/token-utils": "^1.3.18",
     "@solana/spl-token": "^0.1.8",
     "@solana/spl-token-registry": "^0.2.246",
     "@solana/web3.js": "^1.26.0",
+    "@stepfinance/step-swap": "^0.1.10",
     "axios": "^0.21.4",
     "bn.js": "^5.2.0",
     "buffer-layout": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@solana/spl-token": "^0.1.8",
     "@solana/spl-token-registry": "^0.2.246",
     "@solana/web3.js": "^1.26.0",
-    "@stepfinance/step-swap": "^0.1.10",
+    "@stepfinance/step-swap": "^1.1.0",
     "axios": "^0.21.4",
     "bn.js": "^5.2.0",
     "buffer-layout": "^1.2.2"

--- a/src/marketaggregator.ts
+++ b/src/marketaggregator.ts
@@ -6,7 +6,7 @@ import {
   STEP_MINT,
 } from "./sources";
 import { SerumMarketInfoMap } from "./types/serum";
-import { MarketSourcesData } from "./types/marketdata";
+import { MarketDataMap, MarketSourcesData } from "./types/marketdata";
 import { getTokenMap, TokenMap } from "./utils/tokens";
 import { getMintInfoMap } from "./utils/mints";
 import { getSerumMarketInfoMap } from "./utils/serum";
@@ -94,7 +94,10 @@ export class MarketAggregator {
     );
     const serumMarketDataMap = await serumSource.query();
 
-    let markets = { ...serumMarketDataMap, ...coingeckoMarketDataMap };
+    let markets: MarketDataMap = {
+      ...serumMarketDataMap,
+      ...coingeckoMarketDataMap,
+    };
 
     const stepMarketData = coingeckoMarketDataMap[STEP_MINT];
     if (stepMarketData) {

--- a/src/marketaggregator.ts
+++ b/src/marketaggregator.ts
@@ -5,9 +5,13 @@ import {
   StakedStepMarketSource,
   STEP_MINT,
 } from "./sources";
-import { SerumMarketInfoMap } from "./types/serum";
-import { MarketDataMap, MarketSourcesData } from "./types/marketdata";
-import { getTokenMap, TokenMap } from "./utils/tokens";
+import {
+  MarketDataMap,
+  MarketSourcesData,
+  SerumMarketInfoMap,
+  TokenMap,
+} from "./types";
+import { getTokenMap } from "./utils/tokens";
 import { getMintInfoMap } from "./utils/mints";
 import { getSerumMarketInfoMap } from "./utils/serum";
 import { getStarAtlasData } from "./utils/star-atlas";

--- a/src/sources/coingecko.ts
+++ b/src/sources/coingecko.ts
@@ -1,22 +1,13 @@
 import axios from "axios";
-import { ICoinGeckoCoinMarketData } from "../types/coingecko";
+import {
+  TokenMap,
+  MarketDataMap,
+  ICoinGeckoCoinMarketData,
+  CoingeckoTokenMap,
+  tokenInfoHasCoingeckoId,
+} from "../types";
 import { MarketSource } from "./marketsource";
-import { MarketDataMap } from "../types/marketdata";
 import { chunks } from "../utils/web3";
-import { TokenMap } from "../utils/tokens";
-import { TokenExtensions, TokenInfo } from "@solana/spl-token-registry";
-
-type TokenInfoWithCoingeckoId = Omit<TokenInfo, "extensions"> & {
-  extensions: Omit<TokenExtensions, "coingeckoId"> & {
-    readonly coingeckoId: string;
-  };
-};
-
-type CoingeckoTokenMap = { [address: string]: TokenInfoWithCoingeckoId };
-
-const tokenInfoHasCoingeckoId = (
-  tokenInfo: TokenInfo
-): tokenInfo is TokenInfoWithCoingeckoId => !!tokenInfo.extensions?.coingeckoId;
 
 /**
  * A class that retrieves market prices from CoinGecko for a given set of tokens

--- a/src/sources/marketsource.ts
+++ b/src/sources/marketsource.ts
@@ -1,6 +1,6 @@
-import { IMarketData } from "../types/marketdata";
+import { MarketDataMap } from "../types/marketdata";
 
 export interface MarketSource {
   // eslint-disable-next-line no-unused-vars
-  query(...args: any[]): Promise<IMarketData[]>;
+  query(...args: any[]): Promise<MarketDataMap>;
 }

--- a/src/sources/serum.ts
+++ b/src/sources/serum.ts
@@ -5,13 +5,13 @@ import { Market, Orderbook } from "@project-serum/serum";
 import { MarketSource } from "./marketsource";
 import { MarketDataMap } from "../types/marketdata";
 import {
-  ISerumMarketInfo,
   DexMarketParser,
+  ISerumMarketInfo,
   SerumMarketInfoMap,
-} from "../types/serum";
+  TokenMap,
+} from "../types";
 import { cache } from "../utils/account";
 import { getMultipleAccounts } from "../utils/web3";
-import { TokenMap } from "../utils/tokens";
 
 export const SERUM_PROGRAM_ID_V3 =
   "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";

--- a/src/types/coingecko.ts
+++ b/src/types/coingecko.ts
@@ -27,6 +27,6 @@ export interface ICoinGeckoCoinMarketData {
     times: number;
     currency: string;
     percentage: number;
-  };
+  } | null;
   last_updated: string;
 }

--- a/src/types/coingecko.ts
+++ b/src/types/coingecko.ts
@@ -1,3 +1,5 @@
+import { TokenExtensions, TokenInfo } from "@solana/spl-token-registry";
+
 export interface ICoinGeckoCoinMarketData {
   id: string;
   symbol: string;
@@ -30,3 +32,14 @@ export interface ICoinGeckoCoinMarketData {
   } | null;
   last_updated: string;
 }
+
+export type TokenInfoWithCoingeckoId = Omit<TokenInfo, "extensions"> & {
+  extensions: Omit<TokenExtensions, "coingeckoId"> & {
+    readonly coingeckoId: string;
+  };
+};
+export const tokenInfoHasCoingeckoId = (
+  tokenInfo: TokenInfo
+): tokenInfo is TokenInfoWithCoingeckoId => !!tokenInfo.extensions?.coingeckoId;
+
+export type CoingeckoTokenMap = { [address: string]: TokenInfoWithCoingeckoId };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./account";
 export * from "./coingecko";
 export * from "./marketdata";
 export * from "./serum";
+export * from "./star-atlas";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./coingecko";
 export * from "./marketdata";
 export * from "./serum";
 export * from "./star-atlas";
+export * from "./tokens";

--- a/src/types/marketdata.ts
+++ b/src/types/marketdata.ts
@@ -5,3 +5,24 @@ export interface IMarketData {
   price: number;
   metadata?: Record<string, any>;
 }
+
+export type MarketDataMap = {
+  [address: string]: IMarketData;
+};
+
+export type RawMintInfo = {
+  mintAuthority: string | null;
+  supply: string;
+  decimals: number;
+  isInitialized: boolean;
+  freezeAuthority: string | null;
+};
+
+export type MintInfoMap = {
+  [address: string]: RawMintInfo;
+};
+
+export type MarketSourcesData = {
+  markets: MarketDataMap;
+  mintInfo: MintInfoMap;
+}

--- a/src/types/marketdata.ts
+++ b/src/types/marketdata.ts
@@ -25,4 +25,4 @@ export type MintInfoMap = {
 export type MarketSourcesData = {
   markets: MarketDataMap;
   mintInfo: MintInfoMap;
-}
+};

--- a/src/types/serum.ts
+++ b/src/types/serum.ts
@@ -11,6 +11,10 @@ export interface ISerumMarketInfo {
   deprecated: boolean;
 }
 
+export type SerumMarketInfoMap = {
+  [name: string]: ISerumMarketInfo;
+};
+
 export const OrderBookParser = (id: PublicKey, acc: AccountInfo<Buffer>) => {
   const decoded = Orderbook.LAYOUT.decode(acc.data);
 
@@ -33,9 +37,7 @@ export const DexMarketParser = (
   pubkey: PublicKey,
   acc: AccountInfo<Buffer>
 ) => {
-  const decoded = Market.getLayout(DEFAULT_DEX_ID).decode(
-    acc.data
-  );
+  const decoded = Market.getLayout(DEFAULT_DEX_ID).decode(acc.data);
 
   const details = {
     pubkey,

--- a/src/types/star-atlas.ts
+++ b/src/types/star-atlas.ts
@@ -1,0 +1,67 @@
+export interface StarAtlasNFT {
+  _id: string;
+  deactivated: boolean;
+  name: string;
+  description: string;
+  image: string;
+  media: {
+    qrInstagram: string;
+    qrFacebook: string;
+    audio: string;
+    sketchfab: string;
+    thumbnailUrl?: string;
+  };
+  attributes: {
+    itemType: string;
+    rarity: string;
+    tier?: number;
+    class: string;
+    score?: number;
+    musician?: string;
+    spec?: string;
+    category?: string;
+    crewSlots?: number;
+    componentSlots?: number;
+    moduleSlots?: number;
+    unitLength?: number;
+    unitWidth?: number;
+    unitHeight?: number;
+  };
+  symbol: string;
+  markets: {
+    _id?: string;
+    id: string;
+    quotePair: string;
+    serumProgramId?: string;
+  }[];
+  totalSupply?: number;
+  mint: string;
+  network?: string;
+  tradeSettings: {
+    expireTime?: number;
+    saleTime?: number;
+    msrp?: {
+      value: number;
+      currencySymbol: string;
+    };
+  };
+  updatedAt: Date;
+  airdrops: {
+    _id: string;
+    supply: number;
+    id: number;
+  }[];
+  primarySales: {
+    _id?: string;
+    listTimestamp: number;
+    supply?: number;
+    price?: number;
+    isMinted?: boolean;
+    isListed?: boolean;
+    mintTimestamp?: number | null;
+    orderId?: null;
+    expireTimestamp?: number;
+  }[];
+  musician?: string;
+  createdAt?: Date;
+}

--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -1,0 +1,16 @@
+import { TokenExtensions, TokenInfo } from "@solana/spl-token-registry";
+
+export type TokenMap = {
+  [address: string]: TokenInfo;
+};
+
+export type MinimalTokenInfo = Omit<TokenInfo, "extensions"> & {
+  extensions: Pick<
+    TokenExtensions,
+    "coingeckoId" | "website" | "serumV3Usdc" | "serumV3Usdt"
+  >;
+};
+
+export type MinimalTokenMap = {
+  [address: string]: MinimalTokenInfo;
+};

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,19 +1,10 @@
-import {
-  AccountInfo,
-  Connection,
-  PublicKey
-} from "@solana/web3.js";
-import {
-  AccountLayout,
-  u64,
-  MintInfo,
-  MintLayout,
-} from "@solana/spl-token";
+import { AccountInfo, Connection, PublicKey } from "@solana/web3.js";
+import { AccountLayout, u64, MintInfo, MintLayout } from "@solana/spl-token";
 import { Buffer } from "buffer";
 import {
   ParsedAccountBase,
   AccountParser,
-  TokenAccount
+  TokenAccount,
 } from "../types/account";
 
 const pendingMintCalls = new Map<string, Promise<MintInfo>>();
@@ -21,7 +12,6 @@ const mintCache = new Map<string, MintInfo>();
 const pendingCalls = new Map<string, Promise<ParsedAccountBase>>();
 const genericCache = new Map<string, ParsedAccountBase>();
 const keyToAccountParser = new Map<string, AccountParser>();
-
 
 const getMintInfo = async (connection: Connection, pubKey: PublicKey) => {
   /*if (pubKey.equals(SOL_MINT)) {
@@ -114,9 +104,7 @@ export const cache = {
 
     query = connection.getAccountInfo(id).then((data) => {
       if (!data) {
-        throw new Error(
-          "Account not found with addresss ID " + id.toBase58()
-        );
+        throw new Error(`Account not found with address ID ${id.toBase58()}`);
       }
 
       return cache.add(id, data, parser);

--- a/src/utils/mints.ts
+++ b/src/utils/mints.ts
@@ -1,0 +1,52 @@
+import { Connection } from "@solana/web3.js";
+import { deserializeMint } from "@saberhq/token-utils";
+import { TokenMap } from "./tokens";
+import { getMultipleAccounts } from "./web3";
+import { MintInfoMap } from "..";
+
+export type RawMintInfo = {
+  mintAuthority: string | null;
+  supply: string;
+  decimals: number;
+  isInitialized: boolean;
+  freezeAuthority: string | null;
+};
+
+export const getMintInfoMap = async (
+  connection: Connection,
+  tokenMap: TokenMap
+): Promise<MintInfoMap> => {
+  const { keys, array } = await getMultipleAccounts(
+    connection,
+    Array.from(Object.keys(tokenMap)),
+    "confirmed"
+  );
+  return array.reduce<MintInfoMap>((map, tokenAccount, index) => {
+    const address = keys[index];
+    try {
+      const {
+        decimals,
+        freezeAuthority,
+        isInitialized,
+        mintAuthority,
+        supply,
+      } = deserializeMint(tokenAccount.data);
+      return {
+        ...map,
+        [address]: {
+          mintAuthority: mintAuthority?.toBase58() ?? null,
+          supply: supply.toString(),
+          decimals,
+          isInitialized,
+          freezeAuthority: freezeAuthority?.toBase58() ?? null,
+        },
+      };
+    } catch (e) {
+      // Skip mints we cannot parse
+      if ((e as Error).message === "Not a valid Mint") {
+        return map;
+      }
+      throw e;
+    }
+  }, {});
+};

--- a/src/utils/mints.ts
+++ b/src/utils/mints.ts
@@ -1,8 +1,7 @@
 import { Connection } from "@solana/web3.js";
 import { deserializeMint } from "@saberhq/token-utils";
-import { TokenMap } from "./tokens";
+import { TokenMap, MintInfoMap } from "../types";
 import { getMultipleAccounts } from "./web3";
-import { MintInfoMap } from "..";
 
 export type RawMintInfo = {
   mintAuthority: string | null;

--- a/src/utils/serum.ts
+++ b/src/utils/serum.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { ISerumMarketInfo, SerumMarketInfoMap } from "../types/serum";
+
+export const SERUM_MARKET_LIST_URL =
+  "https://raw.githubusercontent.com/step-finance/serum-markets/main/src/markets.json" as const;
+
+export const getSerumMarketInfoMap = async (): Promise<SerumMarketInfoMap> => {
+  const serumMarketResponse = await axios.get<ISerumMarketInfo[]>(
+    SERUM_MARKET_LIST_URL
+  );
+  const { data: serumMarketList } = serumMarketResponse;
+  return serumMarketList.reduce<SerumMarketInfoMap>(
+    (map, marketInfo) => ({
+      ...map,
+      [marketInfo.name]: marketInfo,
+    }),
+    {}
+  );
+};

--- a/src/utils/star-atlas.ts
+++ b/src/utils/star-atlas.ts
@@ -1,10 +1,8 @@
-import { TokenMap } from "./tokens";
-import { SerumMarketInfoMap } from "../types/serum";
-import { SERUM_PROGRAM_ID_V3 } from "../sources/serum";
-import axios from "axios";
-import { StarAtlasNFT } from "../types/star-atlas";
 import { Cluster } from "@solana/web3.js";
 import { TokenListContainer } from "@solana/spl-token-registry";
+import axios from "axios";
+import { SerumMarketInfoMap, StarAtlasNFT, TokenMap } from "../types";
+import { SERUM_PROGRAM_ID_V3 } from "../sources/serum";
 
 export type StarAtlasData = {
   tokenMap: TokenMap;

--- a/src/utils/star-atlas.ts
+++ b/src/utils/star-atlas.ts
@@ -1,0 +1,62 @@
+import { TokenMap } from "./tokens";
+import { SerumMarketInfoMap } from "../types/serum";
+import { SERUM_PROGRAM_ID_V3 } from "../sources/serum";
+import axios from "axios";
+import { StarAtlasNFT } from "../types/star-atlas";
+import { Cluster } from "@solana/web3.js";
+import { TokenListContainer } from "@solana/spl-token-registry";
+
+export type StarAtlasData = {
+  tokenMap: TokenMap;
+  markets: SerumMarketInfoMap;
+};
+
+export const STAR_ATLAS_API_URL =
+  "https://galaxy.production.run.staratlas.one/nfts" as const;
+
+export const getStarAtlasData = async (cluster: Cluster) => {
+  const starAtlasApiResponse = await axios.get<StarAtlasNFT[]>(
+    STAR_ATLAS_API_URL
+  );
+  const starAtlasTokenListContainer = new TokenListContainer(
+    starAtlasApiResponse.data.map(({ mint, symbol }) => ({
+      chainId: 101,
+      address: mint,
+      name: symbol,
+      decimals: 0,
+      symbol: symbol,
+    }))
+  );
+  const starAtlasTokenInfos = starAtlasTokenListContainer
+    .filterByClusterSlug(cluster)
+    .getList();
+  const tokenMap = starAtlasTokenInfos.reduce<TokenMap>(
+    (map, tokenInfo) => ({
+      ...map,
+      [tokenInfo.address]: tokenInfo,
+    }),
+    {}
+  );
+
+  const markets = starAtlasApiResponse.data.reduce<SerumMarketInfoMap>(
+    (map, { markets, symbol }) => {
+      const { id: address, quotePair, serumProgramId } = markets[0];
+      const name = `${symbol}/${quotePair}`;
+      return {
+        ...map,
+        [name]: {
+          deprecated: false,
+          address,
+          name,
+          programId: serumProgramId ? serumProgramId : SERUM_PROGRAM_ID_V3,
+        },
+      };
+    },
+    {}
+  );
+
+  return {
+    tokenMap,
+    markets,
+  };
+};

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -15,16 +15,12 @@ import {
 } from "@stepfinance/step-swap";
 import axios from "axios";
 import { getMultipleAccounts } from "./web3";
-
+import { TokenMap } from "../types";
 
 // shorten the checksummed version of the input address to have 4 characters at start and end
 export function shortenAddress(address: string, chars = 4): string {
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
-
-export type TokenMap = {
-  [address: string]: TokenInfo;
-};
 
 export const getTokenMap = async (
   connection: Connection,

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,0 +1,138 @@
+import { Cluster, Connection, PublicKey } from "@solana/web3.js";
+import {
+  ENV,
+  Strategy,
+  TokenInfo,
+  TokenListContainer,
+  TokenListProvider,
+} from "@solana/spl-token-registry";
+import { deserializeMint } from "@saberhq/token-utils";
+import {
+  STEP_SWAP_PROGRAM_ID,
+  TokenSwap as StepTokenSwap,
+  TokenSwapLayout as StepSwapLayout,
+} from "@stepfinance/step-swap";
+import axios from "axios";
+import { getMultipleAccounts } from "./web3";
+
+// TODO: Update @stepfinance/step-swap to export this
+export const STEP_SWAP_OWNER = new PublicKey(
+  "GkT2mRSujbydLUmA178ykHe7hZtaUpkmX2sfwS8suWb3"
+);
+
+// shorten the checksummed version of the input address to have 4 characters at start and end
+export function shortenAddress(address: string, chars = 4): string {
+  return `${address.slice(0, chars)}...${address.slice(-chars)}`;
+}
+
+export type TokenMap = {
+  [address: string]: TokenInfo;
+};
+
+export const getTokenMap = async (
+  connection: Connection,
+  cluster: Cluster
+): Promise<TokenMap> => {
+  const baseTokenListProvider = new TokenListProvider();
+  const baseTokenList = await baseTokenListProvider.resolve(Strategy.GitHub);
+  const baseTokenInfos = baseTokenList
+    .filterByClusterSlug(cluster)
+    .excludeByTag("lp-token")
+    .excludeByTag("tokenized-stock")
+    .getList();
+
+  const tokenMap: TokenMap = baseTokenInfos.reduce<TokenMap>(
+    (map, tokenInfo) => ({ ...map, [tokenInfo.address]: tokenInfo }),
+    {}
+  );
+
+  const { data: rawStepTokenOverridesList } = await axios.get<TokenInfo[]>(
+    "https://raw.githubusercontent.com/step-finance/token-list-overrides/main/src/token-list.json"
+  );
+  const stepTokenOverridesList = new TokenListContainer(
+    rawStepTokenOverridesList
+  );
+  const stepTokenOverridesTokenInfos = stepTokenOverridesList
+    .filterByClusterSlug(cluster)
+    .getList();
+
+  for (const tokenInfo of stepTokenOverridesTokenInfos) {
+    const { address } = tokenInfo;
+    tokenMap[address] = tokenInfo;
+  }
+
+  if (cluster === "devnet") {
+    const devnetStepAMMTokenInfos = await getDevnetStepAMMTokenInfos(
+      connection,
+      tokenMap
+    );
+    for (const tokenInfo of devnetStepAMMTokenInfos) {
+      const { address } = tokenInfo;
+      if (!tokenMap[address]) {
+        tokenMap[address] = tokenInfo;
+      }
+    }
+  }
+
+  return tokenMap;
+};
+
+const getDevnetStepAMMTokenInfos = async (
+  connection: Connection,
+  tokenMap: TokenMap
+): Promise<TokenInfo[]> => {
+  const poolRegistry = await StepTokenSwap.loadPoolRegistry(
+    connection,
+    STEP_SWAP_OWNER,
+    STEP_SWAP_PROGRAM_ID
+  );
+
+  if (poolRegistry) {
+    const poolAccountAddresses = poolRegistry.accounts
+      .slice(0, poolRegistry.registrySize)
+      .map((publicKey) => publicKey.toBase58());
+
+    const { array } = await getMultipleAccounts(
+      connection,
+      poolAccountAddresses,
+      "single"
+    );
+    const mintSet = new Set<string>();
+    array.forEach((accountInfo) => {
+      // TODO: Update @stepfinance/step-swap with types for layout
+      const poolRawData = StepSwapLayout.decode(accountInfo.data);
+      const mintAString = new PublicKey(poolRawData.mintA).toBase58();
+      const mintBString = new PublicKey(poolRawData.mintB).toBase58();
+      if (!tokenMap[mintAString]) {
+        mintSet.add(mintAString);
+      }
+      if (!tokenMap[mintBString]) {
+        mintSet.add(mintBString);
+      }
+    });
+
+    const { keys, array: rawMintArray } = await getMultipleAccounts(
+      connection,
+      Array.from(mintSet),
+      "confirmed"
+    );
+
+    return rawMintArray.map((rawMint, index) => {
+      const address = keys[index];
+      const { decimals } = deserializeMint(rawMint.data);
+      return {
+        address,
+        chainId: ENV.Devnet,
+        decimals,
+        name: shortenAddress(address),
+        symbol: shortenAddress(address),
+        extensions: {
+          // Default devnet tokens to stablecoin
+          coingeckoId: "usd-coin",
+        },
+      };
+    });
+  }
+
+  return [];
+};

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -8,6 +8,7 @@ import {
 } from "@solana/spl-token-registry";
 import { deserializeMint } from "@saberhq/token-utils";
 import {
+  STEP_SWAP_OWNER,
   STEP_SWAP_PROGRAM_ID,
   TokenSwap as StepTokenSwap,
   TokenSwapLayout as StepSwapLayout,
@@ -15,10 +16,6 @@ import {
 import axios from "axios";
 import { getMultipleAccounts } from "./web3";
 
-// TODO: Update @stepfinance/step-swap to export this
-export const STEP_SWAP_OWNER = new PublicKey(
-  "GkT2mRSujbydLUmA178ykHe7hZtaUpkmX2sfwS8suWb3"
-);
 
 // shorten the checksummed version of the input address to have 4 characters at start and end
 export function shortenAddress(address: string, chars = 4): string {
@@ -99,7 +96,6 @@ const getDevnetStepAMMTokenInfos = async (
     );
     const mintSet = new Set<string>();
     array.forEach((accountInfo) => {
-      // TODO: Update @stepfinance/step-swap with types for layout
       const poolRawData = StepSwapLayout.decode(accountInfo.data);
       const mintAString = new PublicKey(poolRawData.mintA).toBase58();
       const mintBString = new PublicKey(poolRawData.mintB).toBase58();

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -1,5 +1,8 @@
 import {
-  AccountInfo, Commitment, Connection, PublicKey,
+  AccountInfo,
+  Commitment,
+  Connection,
+  PublicKey,
 } from "@solana/web3.js";
 import { Buffer } from "buffer";
 

--- a/tests/coingecko.ts
+++ b/tests/coingecko.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import "mocha";
 
 import { CoinGeckoMarketSource } from "../src/sources/coingecko";
-import { TokenMap } from "../src/utils/tokens";
+import { TokenMap } from "../src/types";
 
 const WRAPPED_SOL_ADDRESS = "So11111111111111111111111111111111111111112";
 

--- a/tests/coingecko.ts
+++ b/tests/coingecko.ts
@@ -2,66 +2,68 @@ import { expect } from "chai";
 import "mocha";
 
 import { CoinGeckoMarketSource } from "../src/sources/coingecko";
+import { TokenMap } from "../src/utils/tokens";
 
 describe("CoinGecko Source", () => {
   describe("Can", () => {
     it("Request market prices", async () => {
+      const testTokenMap: TokenMap = {
+        So11111111111111111111111111111111111111112: {
+          chainId: 101,
+          address: "So11111111111111111111111111111111111111112",
+          symbol: "SOL",
+          name: "Wrapped SOL",
+          decimals: 9,
+          logoURI:
+            "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
+          tags: [],
+          extensions: {
+            website: "https://solana.com/",
+            serumV3Usdc: "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
+            serumV3Usdt: "HWHvQhFmJB3NUcu1aihKmrKegfVxBEHzwVX6yZCKEsi1",
+            coingeckoId: "solana",
+          },
+        },
+        EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
+          chainId: 101,
+          address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          symbol: "USDC",
+          name: "USD Coin",
+          decimals: 6,
+          logoURI:
+            "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
+          tags: ["stablecoin"],
+          extensions: {
+            website: "https://www.centre.io/",
+            coingeckoId: "usd-coin",
+            serumV3Usdt: "77quYg4MGneUdjgXCunt9GgM1usmrxKY31twEy3WHwcS",
+          },
+        },
+        "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E": {
+          chainId: 101,
+          address: "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+          symbol: "BTC",
+          name: "Wrapped Bitcoin (Sollet)",
+          decimals: 6,
+          logoURI:
+            "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E/logo.png",
+          tags: ["wrapped-sollet", "ethereum"],
+          extensions: {
+            bridgeContract:
+              "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
+            serumV3Usdc: "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
+            serumV3Usdt: "C1EuT9VokAKLiW7i2ASnZUvxDoKuKkCpDDeNxAptuNe4",
+            coingeckoId: "bitcoin",
+          },
+        },
+      };
 
-      const testTokens = [
-        {
-          "chainId": 101,
-          "address": "So11111111111111111111111111111111111111112",
-          "symbol": "SOL",
-          "name": "Wrapped SOL",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
-          "tags": [],
-          "extensions": {
-            "website": "https://solana.com/",
-            "serumV3Usdc": "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
-            "serumV3Usdt": "HWHvQhFmJB3NUcu1aihKmrKegfVxBEHzwVX6yZCKEsi1",
-            "coingeckoId": "solana"
-          }
-        },
-        {
-          "chainId": 101,
-          "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-          "symbol": "USDC",
-          "name": "USD Coin",
-          "decimals": 6,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
-          "tags": [
-            "stablecoin"
-          ],
-          "extensions": {
-            "website": "https://www.centre.io/",
-            "coingeckoId": "usd-coin",
-            "serumV3Usdt": "77quYg4MGneUdjgXCunt9GgM1usmrxKY31twEy3WHwcS"
-          }
-        },
-        {
-          "chainId": 101,
-          "address": "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
-          "symbol": "BTC",
-          "name": "Wrapped Bitcoin (Sollet)",
-          "decimals": 6,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E/logo.png",
-          "tags": [
-            "wrapped-sollet",
-            "ethereum"
-          ],
-          "extensions": {
-            "bridgeContract": "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
-            "serumV3Usdc": "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
-            "serumV3Usdt": "C1EuT9VokAKLiW7i2ASnZUvxDoKuKkCpDDeNxAptuNe4",
-            "coingeckoId": "bitcoin"
-          }
-        },
-      ];
-
-      const cgms = new CoinGeckoMarketSource(testTokens);
-      const prices = await cgms.query();
-      expect(prices.length).to.equal(3);
+      const prices = await new CoinGeckoMarketSource().query(testTokenMap);
+      expect(prices).to.include.keys([
+        "So11111111111111111111111111111111111111112",
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+      ]);
     });
   });
 });

--- a/tests/coingecko.ts
+++ b/tests/coingecko.ts
@@ -4,66 +4,73 @@ import "mocha";
 import { CoinGeckoMarketSource } from "../src/sources/coingecko";
 import { TokenMap } from "../src/utils/tokens";
 
-describe("CoinGecko Source", () => {
-  describe("Can", () => {
-    it("Request market prices", async () => {
-      const testTokenMap: TokenMap = {
-        So11111111111111111111111111111111111111112: {
-          chainId: 101,
-          address: "So11111111111111111111111111111111111111112",
-          symbol: "SOL",
-          name: "Wrapped SOL",
-          decimals: 9,
-          logoURI:
-            "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
-          tags: [],
-          extensions: {
-            website: "https://solana.com/",
-            serumV3Usdc: "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
-            serumV3Usdt: "HWHvQhFmJB3NUcu1aihKmrKegfVxBEHzwVX6yZCKEsi1",
-            coingeckoId: "solana",
-          },
-        },
-        EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
-          chainId: 101,
-          address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-          symbol: "USDC",
-          name: "USD Coin",
-          decimals: 6,
-          logoURI:
-            "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
-          tags: ["stablecoin"],
-          extensions: {
-            website: "https://www.centre.io/",
-            coingeckoId: "usd-coin",
-            serumV3Usdt: "77quYg4MGneUdjgXCunt9GgM1usmrxKY31twEy3WHwcS",
-          },
-        },
-        "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E": {
-          chainId: 101,
-          address: "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
-          symbol: "BTC",
-          name: "Wrapped Bitcoin (Sollet)",
-          decimals: 6,
-          logoURI:
-            "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E/logo.png",
-          tags: ["wrapped-sollet", "ethereum"],
-          extensions: {
-            bridgeContract:
-              "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
-            serumV3Usdc: "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
-            serumV3Usdt: "C1EuT9VokAKLiW7i2ASnZUvxDoKuKkCpDDeNxAptuNe4",
-            coingeckoId: "bitcoin",
-          },
-        },
-      };
+const WRAPPED_SOL_ADDRESS = "So11111111111111111111111111111111111111112";
 
-      const prices = await new CoinGeckoMarketSource().query(testTokenMap);
-      expect(prices).to.include.keys([
-        "So11111111111111111111111111111111111111112",
-        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-        "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
-      ]);
-    });
+describe("CoinGecko Source", () => {
+  it("Requests market prices for given token map", async () => {
+    const testTokenMap: TokenMap = {
+      [WRAPPED_SOL_ADDRESS]: {
+        chainId: 101,
+        address: WRAPPED_SOL_ADDRESS,
+        symbol: "WSOL",
+        name: "Wrapped SOL",
+        decimals: 9,
+        logoURI:
+          "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
+        tags: [],
+        extensions: {
+          website: "https://solana.com/",
+          serumV3Usdc: "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
+          serumV3Usdt: "HWHvQhFmJB3NUcu1aihKmrKegfVxBEHzwVX6yZCKEsi1",
+          coingeckoId: "solana",
+        },
+      },
+      EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
+        chainId: 101,
+        address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6,
+        logoURI:
+          "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
+        tags: ["stablecoin"],
+        extensions: {
+          website: "https://www.centre.io/",
+          coingeckoId: "usd-coin",
+          serumV3Usdt: "77quYg4MGneUdjgXCunt9GgM1usmrxKY31twEy3WHwcS",
+        },
+      },
+      "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E": {
+        chainId: 101,
+        address: "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+        symbol: "BTC",
+        name: "Wrapped Bitcoin (Sollet)",
+        decimals: 6,
+        logoURI:
+          "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E/logo.png",
+        tags: ["wrapped-sollet", "ethereum"],
+        extensions: {
+          bridgeContract:
+            "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
+          serumV3Usdc: "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
+          serumV3Usdt: "C1EuT9VokAKLiW7i2ASnZUvxDoKuKkCpDDeNxAptuNe4",
+          coingeckoId: "bitcoin",
+        },
+      },
+    };
+
+    const prices = await new CoinGeckoMarketSource().query(testTokenMap);
+    expect(prices).to.include.keys([
+      "So11111111111111111111111111111111111111112",
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+    ]);
+    const wrappedSOLMarketData =
+      prices["So11111111111111111111111111111111111111112"];
+    expect(wrappedSOLMarketData.source).to.equal("coingecko");
+    expect(wrappedSOLMarketData.address).to.equal(WRAPPED_SOL_ADDRESS);
+    expect(wrappedSOLMarketData.symbol).to.equal("WSOL");
+    expect(wrappedSOLMarketData.price).to.be.a("number");
+    expect(wrappedSOLMarketData.metadata).to.be.undefined;
   });
 });

--- a/tests/marketaggregator.ts
+++ b/tests/marketaggregator.ts
@@ -1,15 +1,19 @@
 import { expect } from "chai";
 import { MarketAggregator } from "../src/marketaggregator";
 
-const endpoint = "https://api.mainnet-beta.solana.com/";
+const MAINNET_BETA_ENDPOINT = "https://api.mainnet-beta.solana.com/";
+const DEVNET_ENDPOINT = "https://api.devnet.solana.com/";
+
 const STEP_ADDRESS = "StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT";
 const XSTEP_MINT = "xStpgUCss9piqeFUk2iLVcvJEGhAdJxJQuwLkXP555G";
+const EXAMPLE_DEVNET_TOKEN =
+  "7XWr8fagdZS4mrXUFexQrCd2nYxahR6AtuQkcF2AYecq";
 
 describe("Market Aggregator", () => {
   describe("#queryLists", () => {
     it("queries common currencies from token-list", async () => {
       const aggregator = new MarketAggregator({
-        endpoint,
+        endpoint: MAINNET_BETA_ENDPOINT,
         cluster: "mainnet-beta",
       });
 
@@ -18,11 +22,8 @@ describe("Market Aggregator", () => {
     });
 
     it("queries mints from Step swap pool registry on devnet", async () => {
-      const devnetEndpoint = "https://api.devnet.solana.com/";
-      const EXAMPLE_DEVNET_TOKEN =
-        "7XWr8fagdZS4mrXUFexQrCd2nYxahR6AtuQkcF2AYecq";
       const aggregator = new MarketAggregator({
-        endpoint: devnetEndpoint,
+        endpoint: DEVNET_ENDPOINT,
         cluster: "devnet",
       });
       await aggregator.queryLists();
@@ -33,7 +34,7 @@ describe("Market Aggregator", () => {
   describe("#querySources", () => {
     it("queries common currencies and their prices", async () => {
       const aggregator = new MarketAggregator({
-        endpoint,
+        endpoint: MAINNET_BETA_ENDPOINT,
         cluster: "mainnet-beta",
       });
 
@@ -43,5 +44,19 @@ describe("Market Aggregator", () => {
       expect(mintInfo).not.to.be.empty;
       expect(mintInfo).to.include.keys([STEP_ADDRESS, XSTEP_MINT]);
     });
+
+    describe("on a devnet cluster", () => {
+      it("loads prices for tokens in Step swap pool registry", async () => {
+        const aggregator = new MarketAggregator({
+          endpoint: DEVNET_ENDPOINT,
+          cluster: "devnet",
+        });
+        const { markets, mintInfo } = await aggregator.querySources();
+        expect(markets).not.to.be.empty;
+        expect(markets).to.include.keys([EXAMPLE_DEVNET_TOKEN]);
+        expect(mintInfo).not.to.be.empty;
+        expect(mintInfo).to.include.keys([EXAMPLE_DEVNET_TOKEN]);
+      });
+    })
   });
 });

--- a/tests/marketaggregator.ts
+++ b/tests/marketaggregator.ts
@@ -8,25 +8,40 @@ const XSTEP_MINT = "xStpgUCss9piqeFUk2iLVcvJEGhAdJxJQuwLkXP555G";
 describe("Market Aggregator", () => {
   describe("#queryLists", () => {
     it("queries common currencies from token-list", async () => {
-      const aggregator = new MarketAggregator(endpoint);
+      const aggregator = new MarketAggregator({
+        endpoint,
+        cluster: "mainnet-beta",
+      });
 
       await aggregator.queryLists();
-      expect(aggregator.tokenInfos.map(({ address }) => address)).to.include(
-        STEP_ADDRESS
-      );
+      expect(aggregator.tokenMap).to.haveOwnProperty(STEP_ADDRESS);
+    });
+
+    it("queries mints from Step swap pool registry on devnet", async () => {
+      const devnetEndpoint = "https://api.devnet.solana.com/";
+      const EXAMPLE_DEVNET_TOKEN =
+        "7XWr8fagdZS4mrXUFexQrCd2nYxahR6AtuQkcF2AYecq";
+      const aggregator = new MarketAggregator({
+        endpoint: devnetEndpoint,
+        cluster: "devnet",
+      });
+      await aggregator.queryLists();
+      expect(aggregator.tokenMap).to.haveOwnProperty(EXAMPLE_DEVNET_TOKEN);
     });
   });
 
   describe("#querySources", () => {
     it("queries common currencies and their prices", async () => {
-      const aggregator = new MarketAggregator(endpoint);
+      const aggregator = new MarketAggregator({
+        endpoint,
+        cluster: "mainnet-beta",
+      });
 
-      const markets = await aggregator.querySources();
-      expect(markets.length).to.gt(0);
-
-      const addresses = markets.map(({ address }) => address);
-      expect(addresses).to.include(STEP_ADDRESS);
-      expect(addresses).to.include(XSTEP_MINT);
+      const { markets, mintInfo } = await aggregator.querySources();
+      expect(markets).not.to.be.empty;
+      expect(markets).to.include.keys([STEP_ADDRESS, XSTEP_MINT]);
+      expect(mintInfo).not.to.be.empty;
+      expect(mintInfo).to.include.keys([STEP_ADDRESS, XSTEP_MINT]);
     });
   });
 });

--- a/tests/serum.ts
+++ b/tests/serum.ts
@@ -1,90 +1,107 @@
 import "mocha";
 import { expect } from "chai";
 
-import { TokenInfo } from "@solana/spl-token-registry";
 import { SerumMarketSource } from "../src/sources/serum";
-import { ISerumMarketInfo } from "../src/types/serum";
+import { SerumMarketInfoMap } from "../src/types/serum";
+import { Connection } from "@solana/web3.js";
+import { TokenMap } from "../src/utils/tokens";
 
-const testMarkets: ISerumMarketInfo[] = [
-  {
-    "address": "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
-    "deprecated": false,
-    "name": "SOL/USDC",
-    "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
+const testMarketInfoMap: SerumMarketInfoMap = {
+  "SOL/USDC": {
+    address: "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
+    deprecated: false,
+    name: "SOL/USDC",
+    programId: "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o",
   },
-  {
-    "address": "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
-    "deprecated": false,
-    "name": "BTC/USDC",
-    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+  "BTC/USDC": {
+    address: "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
+    deprecated: false,
+    name: "BTC/USDC",
+    programId: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
   },
-];
+};
 
-const testTokens: TokenInfo[] = [
-  {
-    "chainId": 101,
-    "address": "So11111111111111111111111111111111111111112",
-    "symbol": "SOL",
-    "name": "Wrapped SOL",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
-    "tags": [],
-    "extensions": {
-      "website": "https://solana.com/",
-      "serumV3Usdc": "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
-      "serumV3Usdt": "HWHvQhFmJB3NUcu1aihKmrKegfVxBEHzwVX6yZCKEsi1",
-      "coingeckoId": "solana"
-    }
+const testTokenMap: TokenMap = {
+  So11111111111111111111111111111111111111112: {
+    chainId: 101,
+    address: "So11111111111111111111111111111111111111112",
+    symbol: "SOL",
+    name: "Wrapped SOL",
+    decimals: 9,
+    logoURI:
+      "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
+    tags: [],
+    extensions: {
+      website: "https://solana.com/",
+      serumV3Usdc: "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
+      serumV3Usdt: "HWHvQhFmJB3NUcu1aihKmrKegfVxBEHzwVX6yZCKEsi1",
+      coingeckoId: "solana",
+    },
   },
-  {
-    "chainId": 101,
-    "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-    "symbol": "USDC",
-    "name": "USD Coin",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
-    "tags": [
-      "stablecoin"
-    ],
-    "extensions": {
-      "website": "https://www.centre.io/",
-      "coingeckoId": "usd-coin",
-      "serumV3Usdt": "77quYg4MGneUdjgXCunt9GgM1usmrxKY31twEy3WHwcS"
-    }
+  EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
+    chainId: 101,
+    address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 6,
+    logoURI:
+      "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
+    tags: ["stablecoin"],
+    extensions: {
+      website: "https://www.centre.io/",
+      coingeckoId: "usd-coin",
+      serumV3Usdt: "77quYg4MGneUdjgXCunt9GgM1usmrxKY31twEy3WHwcS",
+    },
   },
-  {
-    "chainId": 101,
-    "address": "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
-    "symbol": "BTC",
-    "name": "Wrapped Bitcoin (Sollet)",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E/logo.png",
-    "tags": [
-      "wrapped-sollet",
-      "ethereum"
-    ],
-    "extensions": {
-      "bridgeContract": "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
-      "serumV3Usdc": "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
-      "serumV3Usdt": "C1EuT9VokAKLiW7i2ASnZUvxDoKuKkCpDDeNxAptuNe4",
-      "coingeckoId": "bitcoin"
-    }
+  "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E": {
+    chainId: 101,
+    address: "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+    symbol: "BTC",
+    name: "Wrapped Bitcoin (Sollet)",
+    decimals: 6,
+    logoURI:
+      "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E/logo.png",
+    tags: ["wrapped-sollet", "ethereum"],
+    extensions: {
+      bridgeContract:
+        "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
+      serumV3Usdc: "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
+      serumV3Usdt: "C1EuT9VokAKLiW7i2ASnZUvxDoKuKkCpDDeNxAptuNe4",
+      coingeckoId: "bitcoin",
+    },
   },
-];
+};
 const endpoint = "https://api.mainnet-beta.solana.com/";
+const connection = new Connection(endpoint);
 
 describe("Serum Source", () => {
   it("requests market prices", async () => {
-    const serumMarketSource = new SerumMarketSource(testTokens, testMarkets, endpoint);
-    const prices = await serumMarketSource.query();
-    expect(prices.length).to.equal(2);
+    const serumMarketSource = new SerumMarketSource(
+      connection,
+      testTokenMap,
+      testMarketInfoMap
+    );
+    const marketDataMap = await serumMarketSource.query();
+    expect(marketDataMap).to.include.keys([
+      "So11111111111111111111111111111111111111112",
+      "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+    ]);
   });
 
   it("loads market prices data", async () => {
-    const serumMarketSource = new SerumMarketSource(testTokens, testMarkets, endpoint);
+    const serumMarketSource = new SerumMarketSource(
+      connection,
+      testTokenMap,
+      testMarketInfoMap
+    );
     const serumSources = await serumMarketSource.query();
-    const serumSource = serumSources[0];
+    const serumSource =
+      serumSources["So11111111111111111111111111111111111111112"];
     expect(serumSource.metadata).to.exist;
-    expect(serumSource.metadata!.marketPrices).to.have.all.keys("bid", "ask", "mid");
+    expect(serumSource.metadata!.marketPrices).to.have.all.keys(
+      "bid",
+      "ask",
+      "mid"
+    );
   });
 });

--- a/tests/serum.ts
+++ b/tests/serum.ts
@@ -1,10 +1,9 @@
 import "mocha";
 import { expect } from "chai";
+import { Connection } from "@solana/web3.js";
 
 import { SerumMarketSource } from "../src/sources/serum";
-import { SerumMarketInfoMap } from "../src/types/serum";
-import { Connection } from "@solana/web3.js";
-import { TokenMap } from "../src/utils/tokens";
+import { SerumMarketInfoMap, TokenMap } from "../src/types";
 
 const testMarketInfoMap: SerumMarketInfoMap = {
   "SOL/USDC": {

--- a/tests/xstep.ts
+++ b/tests/xstep.ts
@@ -1,7 +1,8 @@
+import { Connection } from "@solana/web3.js";
 import { expect } from "chai";
 import "mocha";
 
-import { StakedStepMarketSource } from "../src/sources/xstep";
+import { StakedStepMarketSource, XSTEP_MINT } from "../src/sources/xstep";
 
 describe("xSTEP source", () => {
   it("Loads price relative to STEP", async () => {
@@ -9,9 +10,13 @@ describe("xSTEP source", () => {
     const mockedStepPrice = 1000;
 
     const endpoint = "https://api.devnet.solana.com/";
-    const xStepSource = new StakedStepMarketSource(endpoint);
-    const [staticXStepMarketData] = await xStepSource.query(staticStepPrice);
-    const [xStepMarketData] = await xStepSource.query(mockedStepPrice);
+    const xStepSource = new StakedStepMarketSource(new Connection(endpoint));
+    const staticXStepMarketData = (await xStepSource.query(staticStepPrice))[
+      XSTEP_MINT
+    ];
+    const xStepMarketData = (await xStepSource.query(mockedStepPrice))[
+      XSTEP_MINT
+    ];
     expect(staticXStepMarketData.price * mockedStepPrice).to.equal(
       xStepMarketData.price
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@
     superstruct "^0.14.2"
     tweetnacl "^1.0.0"
 
-"@stepfinance/step-swap@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@stepfinance/step-swap/-/step-swap-0.1.10.tgz#ef49a6db994d3a0d6af4af0443e32b66305dedb8"
-  integrity sha512-/vRI0SRIy/Heb/by0aO4G4fWHGasagB4KsnT5bmUhsXELQVHRkFWKLRqcumaG1ok1Zhv8MKagIhc4aTWM1BEoQ==
+"@stepfinance/step-swap@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@stepfinance/step-swap/-/step-swap-1.1.0.tgz#2d0f0583bfd93cf1f223e07167009d8caec7ccb1"
+  integrity sha512-yYQ6Tlb5W0F0T/5za3Fk02/tBzkDFhvQa+Tj71/5vifWK+fOatuzDvZZAU3uEI8OxYvc0gFaK9aBPlE5Ab7HiA==
   dependencies:
     "@solana/web3.js" "^1.22.0"
     bn.js "^5.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,6 +160,30 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
+"@saberhq/solana-contrib@^1.3.18":
+  version "1.3.18"
+  resolved "https://registry.yarnpkg.com/@saberhq/solana-contrib/-/solana-contrib-1.3.18.tgz#07087cfe5e01330dde7289f59a62379bc256597b"
+  integrity sha512-aLEYVpSwTI9ZBLCvhdmE7VRKL6ZdcmIaoJDl7jjs9wyWMObcI5W7e6cZZi0B/r47iAweVVmpz0hj8TMU32a1VQ==
+  dependencies:
+    "@types/promise-retry" "^1.1.3"
+    "@types/retry" "^0.12.1"
+    promise-retry "^2.0.1"
+    retry "^0.13.1"
+    tiny-invariant "^1.1.0"
+    tslib "^2.3.1"
+
+"@saberhq/token-utils@^1.3.18":
+  version "1.3.18"
+  resolved "https://registry.yarnpkg.com/@saberhq/token-utils/-/token-utils-1.3.18.tgz#adafe58ba06923b91343629cc72e85e32d5106f3"
+  integrity sha512-tPeBwzcZZ9JzEJGh7jBgq17ym0RsmQMGHdvzrlvPfqcFnOq92V6v9ls0wO6xp8q45istSp1I/jo9k6O8LiqxQg==
+  dependencies:
+    "@saberhq/solana-contrib" "^1.3.18"
+    "@solana/buffer-layout" "^3.0.0"
+    "@solana/spl-token" "^0.1.8"
+    "@ubeswap/token-math" "^4.2.0"
+    tiny-invariant "^1.1.0"
+    tslib "^2.3.1"
+
 "@solana/buffer-layout@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@solana/buffer-layout/-/buffer-layout-3.0.0.tgz#b9353caeb9a1589cb77a1b145bcb1a9a93114326"
@@ -206,6 +230,26 @@
     superstruct "^0.14.2"
     tweetnacl "^1.0.0"
 
+"@solana/web3.js@^1.22.0":
+  version "1.29.2"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.29.2.tgz#05c162f477c226ee3211f8ee8c1c6d4203e08f54"
+  integrity sha512-gtoHzimv7upsKF2DIO4/vNfIMKN+cxSImBHvsdiMyp9IPqb8sctsHVU/+80xXl0JKXVKeairDv5RvVnesJYrtw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@solana/buffer-layout" "^3.0.0"
+    bn.js "^5.0.0"
+    borsh "^0.4.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    cross-fetch "^3.1.4"
+    crypto-hash "^1.2.2"
+    jayson "^3.4.4"
+    js-sha3 "^0.8.0"
+    rpc-websockets "^7.4.2"
+    secp256k1 "^4.0.2"
+    superstruct "^0.14.2"
+    tweetnacl "^1.0.0"
+
 "@solana/web3.js@^1.26.0":
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.26.0.tgz#bdd71616ce0ff40258dfe3a8d3a401ed5658fbae"
@@ -225,6 +269,18 @@
     secp256k1 "^4.0.2"
     superstruct "^0.14.2"
     tweetnacl "^1.0.0"
+
+"@stepfinance/step-swap@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@stepfinance/step-swap/-/step-swap-0.1.10.tgz#ef49a6db994d3a0d6af4af0443e32b66305dedb8"
+  integrity sha512-/vRI0SRIy/Heb/by0aO4G4fWHGasagB4KsnT5bmUhsXELQVHRkFWKLRqcumaG1ok1Zhv8MKagIhc4aTWM1BEoQ==
+  dependencies:
+    "@solana/web3.js" "^1.22.0"
+    bn.js "^5.1.3"
+    buffer-layout "^1.2.0"
+    dotenv "10.0.0"
+    json-to-pretty-yaml "^1.2.2"
+    mkdirp "1.0.4"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -250,6 +306,13 @@
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
   dependencies:
     "@types/node" "*"
 
@@ -309,6 +372,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
+"@types/promise-retry@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/promise-retry/-/promise-retry-1.1.3.tgz#baab427419da9088a1d2f21bf56249c21b3dd43c"
+  integrity sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -318,6 +388,11 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/retry@*", "@types/retry@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
+  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
 "@types/ws@^7.4.4":
   version "7.4.7"
@@ -394,6 +469,19 @@
   dependencies:
     "@typescript-eslint/types" "4.31.0"
     eslint-visitor-keys "^2.0.0"
+
+"@ubeswap/token-math@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@ubeswap/token-math/-/token-math-4.2.0.tgz#639cb4db9da790f9ce6ebf31f2e9a4ae905f4bab"
+  integrity sha512-L3IVv98sm6PZQgry7ciZx0BNvNKCZffRQNaKTnhFvlxaLYSlkRh4iHOcmVYbvn++ipDh7sXpHbcqVZKaKADccw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    big.js "^6.1.1"
+    bn.js "^5.2.0"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.2.3"
+    tiny-invariant "^1.1.0"
+    toformat "^2.0.0"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -573,6 +661,11 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+big.js@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.1.1.tgz#63b35b19dc9775c94991ee5db7694880655d5537"
+  integrity sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -583,7 +676,7 @@ bn.js@^4.11.9:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-bn.js@^5.0.0, bn.js@^5.1.0, bn.js@^5.1.2, bn.js@^5.2.0:
+bn.js@^5.0.0, bn.js@^5.1.0, bn.js@^5.1.2, bn.js@^5.1.3, bn.js@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
@@ -854,6 +947,11 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
+decimal.js-light@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
+
 deep-eql@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
@@ -953,6 +1051,11 @@ enquirer@^2.3.5:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1701,6 +1804,11 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbi@^3.2.3:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.2.5.tgz#b37bb90e0e5c2814c1c2a1bcd8c729888a2e37d6"
+  integrity sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -1725,6 +1833,14 @@ json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+json-to-pretty-yaml@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz#f4cd0bd0a5e8fe1df25aaf5ba118b099fd992d5b"
+  integrity sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=
+  dependencies:
+    remedial "^1.0.7"
+    remove-trailing-spaces "^1.0.6"
 
 json5@^1.0.1:
   version "1.0.1"
@@ -1859,6 +1975,11 @@ minimist@^1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+mkdirp@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^9.1.1:
   version "9.1.1"
@@ -2131,6 +2252,14 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -2182,6 +2311,16 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+remedial@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
+  integrity sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==
+
+remove-trailing-spaces@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz#4354d22f3236374702f58ee373168f6d6887ada7"
+  integrity sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -2204,6 +2343,16 @@ resolve@^1.10.0, resolve@^1.10.1, resolve@^1.20.0:
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -2461,12 +2610,22 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+tiny-invariant@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/toformat/-/toformat-2.0.0.tgz#7a043fd2dfbe9021a4e36e508835ba32056739d8"
+  integrity sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==
 
 toml@^3.0.0:
   version "3.0.0"
@@ -2511,7 +2670,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
This PR reworks the market aggregator to support loading multiple pieces of market data:
- Loads market data as a map
- Loads mint info as a map
- Exposes TokenInfo as a map

This also updates the market sources to return data keyed by mint address. In the future, we can use this format in the API to directly return mapped market data.