### PR TITLE
Update how Serum markets are matched to mints

### DIFF
--- a/src/marketaggregator.ts
+++ b/src/marketaggregator.ts
@@ -6,9 +6,9 @@ import {
   STEP_MINT,
 } from "./sources";
 import {
+  ISerumMarketInfo,
   MarketDataMap,
   MarketSourcesData,
-  SerumMarketInfoMap,
   TokenMap,
 } from "./types";
 import { getTokenMap } from "./utils/tokens";
@@ -28,7 +28,7 @@ export class MarketAggregator {
   readonly connection: Connection;
   readonly cluster: Cluster;
   tokenMap: TokenMap = {};
-  serumMarketMap: SerumMarketInfoMap = {};
+  serumMarkets: ISerumMarketInfo[] = [];
   xStep: StakedStepMarketSource;
   // Map of tokens without CoinGecko IDs
   private serumTokenMap: TokenMap = {};
@@ -62,10 +62,7 @@ export class MarketAggregator {
         },
         {}
       );
-      this.serumMarketMap = {
-        ...starAtlasSerumMarkets,
-        ...serumMarketInfoMap,
-      };
+      this.serumMarkets = [...starAtlasSerumMarkets, ...serumMarketInfoMap];
     } catch (err) {
       console.log(err);
       return false;
@@ -83,7 +80,7 @@ export class MarketAggregator {
     // Ensure lists have always been queried at least once
     if (
       Object.keys(this.tokenMap).length === 0 ||
-      Object.keys(this.serumMarketMap).length === 0
+      this.serumMarkets.length === 0
     ) {
       await this.queryLists();
     }
@@ -94,7 +91,7 @@ export class MarketAggregator {
     const serumSource = new SerumMarketSource(
       this.connection,
       this.serumTokenMap,
-      this.serumMarketMap
+      this.serumMarkets
     );
     const serumMarketDataMap = await serumSource.query();
 

--- a/src/types/serum.ts
+++ b/src/types/serum.ts
@@ -6,14 +6,11 @@ import { cache, MintParser } from "../utils/account";
 
 export interface ISerumMarketInfo {
   address: string;
+  baseMintAddress: string;
+  deprecated: boolean;
   name: string;
   programId: string;
-  deprecated: boolean;
 }
-
-export type SerumMarketInfoMap = {
-  [name: string]: ISerumMarketInfo;
-};
 
 export const OrderBookParser = (id: PublicKey, acc: AccountInfo<Buffer>) => {
   const decoded = Orderbook.LAYOUT.decode(acc.data);

--- a/src/utils/serum.ts
+++ b/src/utils/serum.ts
@@ -1,19 +1,13 @@
 import axios from "axios";
-import { ISerumMarketInfo, SerumMarketInfoMap } from "../types/serum";
+import { ISerumMarketInfo } from "../types/serum";
 
 export const SERUM_MARKET_LIST_URL =
   "https://raw.githubusercontent.com/step-finance/serum-markets/main/src/markets.json" as const;
 
-export const getSerumMarketInfoMap = async (): Promise<SerumMarketInfoMap> => {
+export const getSerumMarketInfoMap = async (): Promise<ISerumMarketInfo[]> => {
   const serumMarketResponse = await axios.get<ISerumMarketInfo[]>(
     SERUM_MARKET_LIST_URL
   );
   const { data: serumMarketList } = serumMarketResponse;
-  return serumMarketList.reduce<SerumMarketInfoMap>(
-    (map, marketInfo) => ({
-      ...map,
-      [marketInfo.name]: marketInfo,
-    }),
-    {}
-  );
+  return serumMarketList;
 };

--- a/tests/marketaggregator.ts
+++ b/tests/marketaggregator.ts
@@ -1,13 +1,13 @@
 import { expect } from "chai";
 import { MarketAggregator } from "../src/marketaggregator";
 
+// TODO: Allow environment variable config of endpoints to avoid rate limits
 const MAINNET_BETA_ENDPOINT = "https://api.mainnet-beta.solana.com/";
 const DEVNET_ENDPOINT = "https://api.devnet.solana.com/";
 
 const STEP_ADDRESS = "StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT";
 const XSTEP_MINT = "xStpgUCss9piqeFUk2iLVcvJEGhAdJxJQuwLkXP555G";
-const EXAMPLE_DEVNET_TOKEN =
-  "7XWr8fagdZS4mrXUFexQrCd2nYxahR6AtuQkcF2AYecq";
+const EXAMPLE_DEVNET_TOKEN = "7XWr8fagdZS4mrXUFexQrCd2nYxahR6AtuQkcF2AYecq";
 
 describe("Market Aggregator", () => {
   describe("#queryLists", () => {
@@ -57,6 +57,6 @@ describe("Market Aggregator", () => {
         expect(mintInfo).not.to.be.empty;
         expect(mintInfo).to.include.keys([EXAMPLE_DEVNET_TOKEN]);
       });
-    })
+    });
   });
 });

--- a/tests/serum.ts
+++ b/tests/serum.ts
@@ -3,22 +3,24 @@ import { expect } from "chai";
 import { Connection } from "@solana/web3.js";
 
 import { SerumMarketSource } from "../src/sources/serum";
-import { SerumMarketInfoMap, TokenMap } from "../src/types";
+import { ISerumMarketInfo, TokenMap } from "../src/types";
 
-const testMarketInfoMap: SerumMarketInfoMap = {
-  "SOL/USDC": {
+const testSerumMarkets: ISerumMarketInfo[] = [
+  {
     address: "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
+    baseMintAddress: "So11111111111111111111111111111111111111112",
     deprecated: false,
     name: "SOL/USDC",
-    programId: "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o",
+    programId: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
   },
-  "BTC/USDC": {
+  {
     address: "A8YFbxQYFVqKZaoYJLLUVcQiWP7G2MeEgW5wsAQgMvFw",
+    baseMintAddress: "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
     deprecated: false,
     name: "BTC/USDC",
     programId: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
   },
-};
+];
 
 const testTokenMap: TokenMap = {
   So11111111111111111111111111111111111111112: {
@@ -78,7 +80,7 @@ describe("Serum Source", () => {
     const serumMarketSource = new SerumMarketSource(
       connection,
       testTokenMap,
-      testMarketInfoMap
+      testSerumMarkets
     );
     const marketDataMap = await serumMarketSource.query();
     expect(marketDataMap).to.include.keys([
@@ -91,7 +93,7 @@ describe("Serum Source", () => {
     const serumMarketSource = new SerumMarketSource(
       connection,
       testTokenMap,
-      testMarketInfoMap
+      testSerumMarkets
     );
     const serumSources = await serumMarketSource.query();
     const serumSource =

--- a/tests/staratlas.ts
+++ b/tests/staratlas.ts
@@ -4,8 +4,14 @@ import "mocha";
 import { getStarAtlasData } from "../src/utils/star-atlas";
 
 describe("Star Atlas", () => {
-  it("Handle multiple markets", async () => {
+  it("Handles multiple markets", async () => {
     const { markets } = await getStarAtlasData("mainnet-beta");
-    expect(markets['PX4/USDC']).to.not.equal(undefined);
+    expect(markets).to.deep.include({
+      address: "MTc1macY8G2v1MubFxDp4W8cooaSBUZvc2KqaCNwhQE",
+      baseMintAddress: "2iMhgB4pbdKvwJHVyitpvX5z1NBNypFonUgaSAt9dtDt",
+      deprecated: false,
+      name: "PX4/USDC",
+      programId: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    });
   });
 });


### PR DESCRIPTION
- Expose `baseMintAddress` key on `ISerumMarketInfo`
- Store Serum markets in an array rather than a map
  * Now that `baseMintAddress` is stored on Serum markets, lookup done through `tokenMap`
- Update Star Atlas NFT market loading
- Update tests