### PR TITLE
Add tests folder to TypeScript configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/declarations

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "test": "mocha -r dotenv-defaults/config",
+    "lint": "eslint src/ tests/ --ext .js,.jsx,.ts,.tsx",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist build",
     "prepublishOnly": "npm run clean && npm run build"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   ],
   "scripts": {
     "test": "mocha -r dotenv-defaults/config",
-    "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist build",
     "prepublishOnly": "npm run clean && npm run build"
   },

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -20,7 +20,9 @@ export interface ParsedAccountBase {
 }
 
 export type AccountParser = (
+  // eslint-disable-next-line no-unused-vars
   pubkey: PublicKey,
+  // eslint-disable-next-line no-unused-vars
   data: AccountInfo<Buffer>
 ) => ParsedAccountBase | undefined;
 

--- a/tests/coingecko.ts
+++ b/tests/coingecko.ts
@@ -84,9 +84,9 @@ const TEST_TOKEN_MAP: TokenMap = {
 describe("CoinGecko Source", () => {
   let prices: MarketDataMap;
 
-  before(async() => {
+  before(async () => {
     prices = await new CoinGeckoMarketSource().query(TEST_TOKEN_MAP);
-  })
+  });
 
   it("requests market prices for given tokens in token map", () => {
     expect(prices).to.include.keys([
@@ -98,18 +98,16 @@ describe("CoinGecko Source", () => {
   });
 
   it("properly sets market data values", () => {
-    const wrappedSOLMarketData =
-      prices[WRAPPED_SOL_ADDRESS];
+    const wrappedSOLMarketData = prices[WRAPPED_SOL_ADDRESS]!;
     expect(wrappedSOLMarketData.source).to.equal("coingecko");
     expect(wrappedSOLMarketData.address).to.equal(WRAPPED_SOL_ADDRESS);
     expect(wrappedSOLMarketData.symbol).to.equal("WSOL");
     expect(wrappedSOLMarketData.price).to.be.a("number");
     expect(wrappedSOLMarketData.metadata).to.be.undefined;
-  })
+  });
 
   it("Overrides TerraUSD coins with malformed CoinGecko ID", () => {
-    const wrappedUSTMarketData =
-      prices[UST_ADDRESS];
+    const wrappedUSTMarketData = prices[UST_ADDRESS]!;
     expect(wrappedUSTMarketData.source).to.equal("coingecko");
     expect(wrappedUSTMarketData.address).to.equal(UST_ADDRESS);
     expect(wrappedUSTMarketData.symbol).to.equal("swtUST-9");

--- a/tests/serum.ts
+++ b/tests/serum.ts
@@ -96,7 +96,7 @@ describe("Serum Source", () => {
     );
     const serumSources = await serumMarketSource.query();
     const serumSource =
-      serumSources["So11111111111111111111111111111111111111112"];
+      serumSources["So11111111111111111111111111111111111111112"]!;
     expect(serumSource.metadata).to.exist;
     expect(serumSource.metadata!.marketPrices).to.have.all.keys(
       "bid",

--- a/tests/xstep.ts
+++ b/tests/xstep.ts
@@ -18,8 +18,8 @@ describe("xSTEP source", () => {
     const xStepMarketData = (await xStepSource.query(mockedStepPrice))[
       XSTEP_MINT
     ];
-    expect(staticXStepMarketData.price * mockedStepPrice).to.equal(
-      xStepMarketData.price
+    expect(staticXStepMarketData!.price * mockedStepPrice).to.equal(
+      xStepMarketData!.price
     );
   });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "target": "es6",
     "module": "commonjs",
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
+    "noEmit": true,
     "noUncheckedIndexedAccess": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -17,6 +17,7 @@
     "./node_modules",
   ],
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "tests/**/*"
   ]
 }


### PR DESCRIPTION
Because our `tsconfig.json` does not include the `tests` folder, #17 shipped with TypeScript errors for our Mocha tests. This PR updates the `tsconfig.json` to include that folder in its configuration and fixes the respective tests. It also includes the `tests` folder in linting with ESLint.