### PR TITLE
Fixes/saber registry override

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@project-serum/anchor": "^0.18.2",
-    "@project-serum/serum": "^0.13.60",
-    "@saberhq/token-utils": "^1.12.4",
+    "@project-serum/anchor": "^0.20.1",
+    "@project-serum/serum": "^0.13.61",
+    "@saberhq/token-utils": "^1.12.32",
     "@solana/spl-token": "^0.1.8",
     "@solana/spl-token-registry": "^0.2.429",
     "@solana/web3.js": "^1.31.0",

--- a/src/sources/coingecko.ts
+++ b/src/sources/coingecko.ts
@@ -30,7 +30,7 @@ export class CoinGeckoMarketSource implements MarketSource {
         let tokenInfo: TokenInfoWithCoingeckoId = baseTokenInfo;
         let coingeckoId: string = tokenInfo.extensions.coingeckoId;
         // Hack to work around TerraUSD CoinGecko ID mismapping
-        if (coingeckoId === "terra-usd") {
+        /*if (coingeckoId === "terra-usd") {
           coingeckoId = "terrausd";
           tokenInfo = {
             ...tokenInfo,
@@ -39,7 +39,7 @@ export class CoinGeckoMarketSource implements MarketSource {
               coingeckoId: "terrausd",
             },
           };
-        }
+        }*/
         coingeckoTokenMap[tokenInfo.address] = tokenInfo;
         coingeckoIds.add(coingeckoId);
       }

--- a/src/sources/coingecko.ts
+++ b/src/sources/coingecko.ts
@@ -29,17 +29,6 @@ export class CoinGeckoMarketSource implements MarketSource {
       if (tokenInfoHasCoingeckoId(baseTokenInfo)) {
         let tokenInfo: TokenInfoWithCoingeckoId = baseTokenInfo;
         let coingeckoId: string = tokenInfo.extensions.coingeckoId;
-        // Hack to work around TerraUSD CoinGecko ID mismapping
-        /*if (coingeckoId === "terra-usd") {
-          coingeckoId = "terrausd";
-          tokenInfo = {
-            ...tokenInfo,
-            extensions: {
-              ...tokenInfo.extensions,
-              coingeckoId: "terrausd",
-            },
-          };
-        }*/
         coingeckoTokenMap[tokenInfo.address] = tokenInfo;
         coingeckoIds.add(coingeckoId);
       }

--- a/src/sources/xstep.ts
+++ b/src/sources/xstep.ts
@@ -63,6 +63,9 @@ export class StakedStepMarketSource implements MarketSource {
       return {};
     }
 
+    // Trial fix for intermittent BlockhashNotFound error.
+    await this.connection.getRecentBlockhash("max");
+
     const res = await this.program.simulate.emitPrice!({
       accounts: {
         tokenMint: new web3.PublicKey(STEP_MINT),

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -86,10 +86,19 @@ export const getTokenMap = async (
     const { address } = tokenInfo;
     try {
       new PublicKey(address);
-      tokenMap[address] = overrideCoingeckoId(tokenInfo);
+      const ti = tokenMap[address];
+      // Don't override if coingeckoId already exists
+      if (ti && ti.extensions?.coingeckoId === undefined) {
+        tokenMap[address] = tokenInfo;
+      }
     } catch (e) {
       console.error(e);
     }
+  }
+
+  for (const tokenInfo of Object.values(tokenMap)) {
+    const { address } = tokenInfo;
+    tokenMap[address] = overrideCoingeckoId(tokenInfo);
   }
 
   if (cluster === "devnet") {
@@ -139,27 +148,37 @@ const overrideCoingeckoId = (tokenInfo: TokenInfo): TokenInfo => {
           },
         };
         break;
-    }
-  } else {
-    const tags = tokenInfo.tags ?? [];
-    if (tags.includes("saber-mkt-luna")) {
-      updatedTokenInfo = {
-        ...tokenInfo,
-        extensions: {
-          ...tokenInfo.extensions,
-          coingeckoId: "terra-luna",
-        },
-      };
-    } else if (tags.includes("saber-mkt-sol")) {
-      updatedTokenInfo = {
-        ...tokenInfo,
-        extensions: {
-          ...tokenInfo.extensions,
-          coingeckoId: "solana",
-        },
-      };
+      case "wrapped-terra":
+        updatedTokenInfo = {
+          ...tokenInfo,
+          extensions: {
+            ...tokenInfo.extensions,
+            coingeckoId: "terra-luna",
+          },
+        };
+        break;
     }
   }
+
+  const tags = tokenInfo.tags ?? [];
+  if (tags.includes("saber-mkt-luna")) {
+    updatedTokenInfo = {
+      ...tokenInfo,
+      extensions: {
+        ...tokenInfo.extensions,
+        coingeckoId: "terra-luna",
+      },
+    };
+  } else if (tags.includes("saber-mkt-sol")) {
+    updatedTokenInfo = {
+      ...tokenInfo,
+      extensions: {
+        ...tokenInfo.extensions,
+        coingeckoId: "solana",
+      },
+    };
+  }
+
   return updatedTokenInfo ? updatedTokenInfo : tokenInfo;
 };
 

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -158,25 +158,25 @@ const overrideCoingeckoId = (tokenInfo: TokenInfo): TokenInfo => {
         };
         break;
     }
-  }
-
-  const tags = tokenInfo.tags ?? [];
-  if (tags.includes("saber-mkt-luna")) {
-    updatedTokenInfo = {
-      ...tokenInfo,
-      extensions: {
-        ...tokenInfo.extensions,
-        coingeckoId: "terra-luna",
-      },
-    };
-  } else if (tags.includes("saber-mkt-sol")) {
-    updatedTokenInfo = {
-      ...tokenInfo,
-      extensions: {
-        ...tokenInfo.extensions,
-        coingeckoId: "solana",
-      },
-    };
+  } else {
+    const tags = tokenInfo.tags ?? [];
+    if (tags.includes("saber-mkt-luna")) {
+      updatedTokenInfo = {
+        ...tokenInfo,
+        extensions: {
+          ...tokenInfo.extensions,
+          coingeckoId: "terra-luna",
+        },
+      };
+    } else if (tags.includes("saber-mkt-sol")) {
+      updatedTokenInfo = {
+        ...tokenInfo,
+        extensions: {
+          ...tokenInfo.extensions,
+          coingeckoId: "solana",
+        },
+      };
+    }
   }
 
   return updatedTokenInfo ? updatedTokenInfo : tokenInfo;

--- a/tests/coingecko.ts
+++ b/tests/coingecko.ts
@@ -75,7 +75,7 @@ const TEST_TOKEN_MAP: TokenMap = {
       address: "uusd",
       bridgeContract:
         "https://finder.terra.money/columbus-5/address/terra10nmmwe8r3g99a9newtqa7a75xfgs2e8z87r2sf",
-      coingeckoId: "terra-usd",
+      coingeckoId: "terrausd",
       website: "https://app.saber.so",
     },
   },
@@ -106,12 +106,12 @@ describe("CoinGecko Source", () => {
     expect(wrappedSOLMarketData.metadata).to.be.undefined;
   });
 
-  it("Overrides TerraUSD coins with malformed CoinGecko ID", () => {
+  /*it("Overrides TerraUSD coins with malformed CoinGecko ID", () => {
     const wrappedUSTMarketData = prices[UST_ADDRESS]!;
     expect(wrappedUSTMarketData.source).to.equal("coingecko");
     expect(wrappedUSTMarketData.address).to.equal(UST_ADDRESS);
     expect(wrappedUSTMarketData.symbol).to.equal("swtUST-9");
     expect(wrappedUSTMarketData.price).to.be.a("number");
     expect(wrappedUSTMarketData.metadata).to.be.undefined;
-  });
+  });*/
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,17 +112,17 @@
     snake-case "^3.0.4"
     toml "^3.0.0"
 
-"@project-serum/anchor@^0.18.2":
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.18.2.tgz#0f13b5c2046446b7c24cf28763eec90febb28485"
-  integrity sha512-uyjiN/3Ipp+4hrZRm/hG18HzGLZyvP790LXrCsGO3IWxSl28YRhiGEpKnZycfMW94R7nxdUoE3wY67V+ZHSQBQ==
+"@project-serum/anchor@^0.20.1":
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.20.1.tgz#0937807e807e8332aa708cfef4bcb6cbb88b4129"
+  integrity sha512-2TuBmGUn9qeYz6sJINJlElrBuPsaUAtYyUsJ3XplEBf1pczrANAgs5ceJUFzdiqGEWLn+84ObSdBeChT/AXYFA==
   dependencies:
     "@project-serum/borsh" "^0.2.2"
     "@solana/web3.js" "^1.17.0"
     base64-js "^1.5.1"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
-    buffer-layout "^1.2.0"
+    buffer-layout "^1.2.2"
     camelcase "^5.3.1"
     crypto-hash "^1.3.0"
     eventemitter3 "^4.0.7"
@@ -140,10 +140,10 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
-"@project-serum/serum@^0.13.60":
-  version "0.13.60"
-  resolved "https://registry.yarnpkg.com/@project-serum/serum/-/serum-0.13.60.tgz#abeb3355ebc1895d685250df5965f688502ebcbb"
-  integrity sha512-fGsp9F0ZAS48YQ2HNy+6CNoifJESFXxVsOLPd9QK1XNV8CTuQoECOnVXxV6s5cKGre8pLNq5hrhi5J6aCGauEQ==
+"@project-serum/serum@^0.13.61":
+  version "0.13.61"
+  resolved "https://registry.yarnpkg.com/@project-serum/serum/-/serum-0.13.61.tgz#1f0e6dfa7786a71e4317593911e9915d8b2a06e6"
+  integrity sha512-aebaRGQ0/K7a5kJ9UXO59BAQFJILVu5jbGobU8GD2CTSy6SPceprB6/pgZmZLQIabhXWUHaZRF/wXIClgWataA==
   dependencies:
     "@project-serum/anchor" "^0.11.1"
     "@solana/spl-token" "^0.1.6"
@@ -151,10 +151,10 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
-"@saberhq/solana-contrib@^1.12.4":
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/@saberhq/solana-contrib/-/solana-contrib-1.12.4.tgz#eb1381a4f3de5a0584b083a1eae90e6e2c2a8f30"
-  integrity sha512-0i61JKu+7SGYfdmzKTSYrPxlp/+eDBNXRyGKVFovGCo0Jw6RzUmVA2cX5QWbMP6aq0oOPYCMKWkn1TWkR+qzLg==
+"@saberhq/solana-contrib@^1.12.32":
+  version "1.12.32"
+  resolved "https://registry.yarnpkg.com/@saberhq/solana-contrib/-/solana-contrib-1.12.32.tgz#577f7462e7d18435c951a894f497f1195db75005"
+  integrity sha512-PYnoVmk6ByX85J4GzXUqFUyx1Yi1TvWrpDnptF87Kzc2CPl3Lkhnktbkc4JlMOZYenoknh2114zxn+vbQ3fNNQ==
   dependencies:
     "@types/promise-retry" "^1.1.3"
     "@types/retry" "^0.12.1"
@@ -163,12 +163,12 @@
     tiny-invariant "^1.2.0"
     tslib "^2.3.1"
 
-"@saberhq/token-utils@^1.12.4":
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/@saberhq/token-utils/-/token-utils-1.12.4.tgz#7cf25bbc5694cb83a4522433864372db4f00a925"
-  integrity sha512-CXQBkopq/OBO+9hBQ2W1bwdN0IQ0/pE/ninIF/9LWopEd0nlYdzy+j0DqJ5wipl2l3Q4jb4dj5AbcJ4PRFkHPg==
+"@saberhq/token-utils@^1.12.32":
+  version "1.12.32"
+  resolved "https://registry.yarnpkg.com/@saberhq/token-utils/-/token-utils-1.12.32.tgz#36b31c1011e89d031d4fae0ae4a7a4f912d25e14"
+  integrity sha512-7/z8V5pR+mYPkNDO+oYJwzp6dgegRqvF05SK40oGToavvGiRayOOQxwdfan9Jf60LFz68hHwYZQkoRKsif5HAg==
   dependencies:
-    "@saberhq/solana-contrib" "^1.12.4"
+    "@saberhq/solana-contrib" "^1.12.32"
     "@solana/buffer-layout" "^4.0.0"
     "@solana/spl-token" "^0.1.8"
     "@ubeswap/token-math" "^4.4.1"


### PR DESCRIPTION
* Saber registry was clobbering tokens in token-list and token-overrides with TokenInfo's that had no coingeckoId's
* Remove the other coingecko hack
* Possible fix for block hash error
* Updated some of the solana deps