### PR TITLE
Update getMultipleAccounts consumers to handle new typings

### DIFF
--- a/src/utils/mints.ts
+++ b/src/utils/mints.ts
@@ -1,7 +1,7 @@
 import { Connection } from "@solana/web3.js";
 import { deserializeMint } from "@saberhq/token-utils";
 import { TokenMap, MintInfoMap } from "../types";
-import { getMultipleAccounts } from "./web3";
+import { getMultipleAccounts, isAccountInfoBuffer } from "./web3";
 
 export type RawMintInfo = {
   mintAuthority: string | null;
@@ -22,7 +22,7 @@ export const getMintInfoMap = async (
   );
   return array.reduce<MintInfoMap>((map, tokenAccount, index) => {
     const address = keys[index];
-    if (!address) {
+    if (!address || !isAccountInfoBuffer(tokenAccount)) {
       return map;
     }
 

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -14,6 +14,10 @@ export function chunks<T>(array: T[], size: number): T[][] {
   ).map((_, index) => array.slice(index * size, (index + 1) * size));
 }
 
+export const isAccountInfoBuffer = (
+  accountInfo: AccountInfo<Buffer | ParsedAccountData>
+): accountInfo is AccountInfo<Buffer> => Buffer.isBuffer(accountInfo.data);
+
 export const getMultipleAccounts = async (
   connection: Connection,
   keys: string[],


### PR DESCRIPTION
- Add `isAccountInfoBuffer` helper for determining if data is not yet parsed
- Update cache methods to only add if unparsed data
  * Deserializers expect `Buffer` data
- Add `Buffer` type checking to mint/token utils