### PR TITLE
fetch mint info directly from chain, not cache

### DIFF
--- a/src/sources/invictus.ts
+++ b/src/sources/invictus.ts
@@ -1,9 +1,11 @@
-import { Connection } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 
 import { MarketSource } from "./marketsource";
 import type { MarketDataMap } from "../types/marketdata";
 import { cache } from "../utils/cache";
 import { TokenAccountParser } from "../utils/parsers";
+import { getMintInfo, getTokenAccount } from "@saberhq/token-utils";
+import { Provider, SolanaReadonlyProvider } from "@saberhq/solana-contrib";
 
 export const INVICTUS_MINT = "inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY";
 export const STAKED_INVICTUS_MINT =
@@ -18,6 +20,7 @@ export const LOCKED_STAKED_INVICTUS_MINT =
  */
 export class StakedInvictusMarketSource implements MarketSource {
   readonly connection: Connection;
+  readonly provider: Provider;
 
   /**
    * Create the class
@@ -26,6 +29,9 @@ export class StakedInvictusMarketSource implements MarketSource {
    */
   constructor(connection: Connection) {
     this.connection = connection;
+    this.provider = new SolanaReadonlyProvider(
+      connection
+    ) as unknown as Provider;
   }
 
   /**
@@ -39,31 +45,29 @@ export class StakedInvictusMarketSource implements MarketSource {
       return {};
     }
 
-    const stakedVault = await cache.query(
-      this.connection,
-      STAKED_INVICTUS_VAULT,
-      TokenAccountParser
+    const stakedVault = await getTokenAccount(
+      this.provider,
+      new PublicKey(STAKED_INVICTUS_VAULT)
     );
-    const stakedInvictusMint = await cache.queryMint(
-      this.connection,
-      STAKED_INVICTUS_MINT
+    const stakedInvictusMint = await getMintInfo(
+      this.provider,
+      new PublicKey(STAKED_INVICTUS_MINT)
     );
-    const totalInvictusStaked = stakedVault.info.amount;
+    const totalInvictusStaked = stakedVault.amount.toNumber();
     const invictusRatio =
       totalInvictusStaked / stakedInvictusMint.supply.toNumber();
 
     const stakedInvictusPrice = invictusMarketData.price * invictusRatio;
 
-    const lockedStakedVault = await cache.query(
-      this.connection,
-      LOCKED_STAKED_INVICTUS_VAULT,
-      TokenAccountParser
+    const lockedStakedVault = await getTokenAccount(
+      this.provider,
+      new PublicKey(LOCKED_STAKED_INVICTUS_VAULT)
     );
-    const lockedStakedInvictusMint = await cache.queryMint(
-      this.connection,
-      LOCKED_STAKED_INVICTUS_MINT
+    const lockedStakedInvictusMint = await getMintInfo(
+      this.provider,
+      new PublicKey(LOCKED_STAKED_INVICTUS_MINT)
     );
-    const totalInvictusLockedStaked = lockedStakedVault.info.amount;
+    const totalInvictusLockedStaked = lockedStakedVault.amount.toNumber();
     const lockedInvictusRatio =
       totalInvictusLockedStaked / lockedStakedInvictusMint.supply.toNumber();
 


### PR DESCRIPTION
The vault and mint data for invictus should not be cached, since it is constantly change. 

- Used saber fetch utils for token accounts and mints directly from chain